### PR TITLE
feature: implement schemas for FlatBuffer serialization

### DIFF
--- a/Unity.Mathematics.Serializable/Schemas/Unity.Mathematics.Tables.fbs
+++ b/Unity.Mathematics.Serializable/Schemas/Unity.Mathematics.Tables.fbs
@@ -1,0 +1,623 @@
+// Flatbuffer schema for containing generic math types (Linear Algebra)
+
+include "Unity.Mathematics.fbs";
+
+namespace Unity.Mathematics.Serializable.Tables;
+
+attribute "fs_serializer";
+
+///-----------------------------------------------------------------------------
+/// single element tables
+
+table Float2 (fs_serializer)
+{
+    value: float2 (required);
+}
+
+table Float3 (fs_serializer)
+{
+    value: float3 (required);
+}
+
+table Float4 (fs_serializer)
+{
+    value: float4 (required);
+}
+
+table Quaternion (fs_serializer)
+{
+    value: quaternion (required);
+}
+
+table Float2x2 (fs_serializer)
+{
+    value: float2x2 (required);
+}
+
+table Float2x3 (fs_serializer)
+{
+    value: float2x3 (required);
+}
+
+table Float2x4 (fs_serializer)
+{
+    value: float2x4 (required);
+}
+
+table Float3x2 (fs_serializer)
+{
+    value: float3x2 (required);
+}
+
+table Float3x3 (fs_serializer)
+{
+    value: float3x3 (required);
+}
+
+table Float3x4 (fs_serializer)
+{
+    value: float3x4 (required);
+}
+
+table Float4x2 (fs_serializer)
+{
+    value: float4x2 (required);
+}
+
+table Float4x3 (fs_serializer)
+{
+    value: float4x3 (required);
+}
+
+table Float4x4 (fs_serializer)
+{
+    value: float4x4 (required);
+}
+
+table Int2 (fs_serializer)
+{
+    value: int2 (required);
+}
+
+table Int3 (fs_serializer)
+{
+    value: int3 (required);
+}
+
+table Int4 (fs_serializer)
+{
+    value: int4 (required);
+}
+
+table Int2x2 (fs_serializer)
+{
+    value: int2x2 (required);
+}
+
+table Int2x3 (fs_serializer)
+{
+    value: int2x3 (required);
+}
+
+table Int2x4 (fs_serializer)
+{
+    value: int2x4 (required);
+}
+
+table Int3x2 (fs_serializer)
+{
+    value: int3x2 (required);
+}
+
+table Int3x3 (fs_serializer)
+{
+    value: int3x3 (required);
+}
+
+table Int3x4 (fs_serializer)
+{
+    value: int3x4 (required);
+}
+
+table Int4x2 (fs_serializer)
+{
+    value: int4x2 (required);
+}
+
+table Int4x3 (fs_serializer)
+{
+    value: int4x3 (required);
+}
+
+table Int4x4 (fs_serializer)
+{
+    value: int4x4 (required);
+}
+
+table UInt2 (fs_serializer)
+{
+    value: uint2 (required);
+}
+
+table UInt3 (fs_serializer)
+{
+    value: uint3 (required);
+}
+
+table UInt4 (fs_serializer)
+{
+    value: uint4 (required);
+}
+
+table UInt2x2 (fs_serializer)
+{
+    value: uint2x2 (required);
+}
+
+table UInt2x3 (fs_serializer)
+{
+    value: uint2x3 (required);
+}
+
+table UInt2x4 (fs_serializer)
+{
+    value: uint2x4 (required);
+}
+
+table UInt3x2 (fs_serializer)
+{
+    value: uint3x2 (required);
+}
+
+table UInt3x3 (fs_serializer)
+{
+    value: uint3x3 (required);
+}
+
+table UInt3x4 (fs_serializer)
+{
+    value: uint3x4 (required);
+}
+
+table UInt4x2 (fs_serializer)
+{
+    value: uint4x2 (required);
+}
+
+table UInt4x3 (fs_serializer)
+{
+    value: uint4x3 (required);
+}
+
+table UInt4x4 (fs_serializer)
+{
+    value: uint4x4 (required);
+}
+
+table Bool2 (fs_serializer)
+{
+    value: bool2 (required);
+}
+
+table Bool3 (fs_serializer)
+{
+    value: bool3 (required);
+}
+
+table Bool4 (fs_serializer)
+{
+    value: bool4 (required);
+}
+
+table Bool2x2 (fs_serializer)
+{
+    value: bool2x2 (required);
+}
+
+table Bool2x3 (fs_serializer)
+{
+    value: bool2x3 (required);
+}
+
+table Bool2x4 (fs_serializer)
+{
+    value: bool2x4 (required);
+}
+
+table Bool3x2 (fs_serializer)
+{
+    value: bool3x2 (required);
+}
+
+table Bool3x3 (fs_serializer)
+{
+    value: bool3x3 (required);
+}
+
+table Bool3x4 (fs_serializer)
+{
+    value: bool3x4 (required);
+}
+
+table Bool4x2 (fs_serializer)
+{
+    value: bool4x2 (required);
+}
+
+table Bool4x3 (fs_serializer)
+{
+    value: bool4x3 (required);
+}
+
+table Bool4x4 (fs_serializer)
+{
+    value: bool4x4 (required);
+}
+
+table Double2 (fs_serializer)
+{
+    value: double2 (required);
+}
+
+table Double3 (fs_serializer)
+{
+    value: double3 (required);
+}
+
+table Double4 (fs_serializer)
+{
+    value: double4 (required);
+}
+
+table Double2x2 (fs_serializer)
+{
+    value: double2x2 (required);
+}
+
+table Double2x3 (fs_serializer)
+{
+    value: double2x3 (required);
+}
+
+table Double2x4 (fs_serializer)
+{
+    value: double2x4 (required);
+}
+
+table Double3x2 (fs_serializer)
+{
+    value: double3x2 (required);
+}
+
+table Double3x3 (fs_serializer)
+{
+    value: double3x3 (required);
+}
+
+table Double3x4 (fs_serializer)
+{
+    value: double3x4 (required);
+}
+
+table Double4x2 (fs_serializer)
+{
+    value: double4x2 (required);
+}
+
+table Double4x3 (fs_serializer)
+{
+    value: double4x3 (required);
+}
+
+table Double4x4 (fs_serializer)
+{
+    value: double4x4 (required);
+}
+
+///-----------------------------------------------------------------------------
+/// list elements tables
+
+table ManyFloat2 (fs_serializer)
+{
+    values: [float2] (required);
+}
+
+table ManyFloat3 (fs_serializer)
+{
+    values: [float3] (required);
+}
+
+table ManyFloat4 (fs_serializer)
+{
+    values: [float4] (required);
+}
+
+table ManyQuaternion (fs_serializer)
+{
+    values: [quaternion] (required);
+}
+
+table ManyFloat2x2 (fs_serializer)
+{
+    values: [float2x2] (required);
+}
+
+table ManyFloat2x3 (fs_serializer)
+{
+    values: [float2x3] (required);
+}
+
+table ManyFloat2x4 (fs_serializer)
+{
+    values: [float2x4] (required);
+}
+
+table ManyFloat3x2 (fs_serializer)
+{
+    values: [float3x2] (required);
+}
+
+table ManyFloat3x3 (fs_serializer)
+{
+    values: [float3x3] (required);
+}
+
+table ManyFloat3x4 (fs_serializer)
+{
+    values: [float3x4] (required);
+}
+
+table ManyFloat4x2 (fs_serializer)
+{
+    values: [float4x2] (required);
+}
+
+table ManyFloat4x3 (fs_serializer)
+{
+    values: [float4x3] (required);
+}
+
+table ManyFloat4x4 (fs_serializer)
+{
+    values: [float4x4] (required);
+}
+
+table ManyInt2 (fs_serializer)
+{
+    values: [int2] (required);
+}
+
+table ManyInt3 (fs_serializer)
+{
+    values: [int3] (required);
+}
+
+table ManyInt4 (fs_serializer)
+{
+    values: [int4] (required);
+}
+
+table ManyInt2x2 (fs_serializer)
+{
+    values: [int2x2] (required);
+}
+
+table ManyInt2x3 (fs_serializer)
+{
+    values: [int2x3] (required);
+}
+
+table ManyInt2x4 (fs_serializer)
+{
+    values: [int2x4] (required);
+}
+
+table ManyInt3x2 (fs_serializer)
+{
+    values: [int3x2] (required);
+}
+
+table ManyInt3x3 (fs_serializer)
+{
+    values: [int3x3] (required);
+}
+
+table ManyInt3x4 (fs_serializer)
+{
+    values: [int3x4] (required);
+}
+
+table ManyInt4x2 (fs_serializer)
+{
+    values: [int4x2] (required);
+}
+
+table ManyInt4x3 (fs_serializer)
+{
+    values: [int4x3] (required);
+}
+
+table ManyInt4x4 (fs_serializer)
+{
+    values: [int4x4] (required);
+}
+
+table ManyUInt2 (fs_serializer)
+{
+    values: [uint2] (required);
+}
+
+table ManyUInt3 (fs_serializer)
+{
+    values: [uint3] (required);
+}
+
+table ManyUInt4 (fs_serializer)
+{
+    values: [uint4] (required);
+}
+
+table ManyUInt2x2 (fs_serializer)
+{
+    values: [uint2x2] (required);
+}
+
+table ManyUInt2x3 (fs_serializer)
+{
+    values: [uint2x3] (required);
+}
+
+table ManyUInt2x4 (fs_serializer)
+{
+    values: [uint2x4] (required);
+}
+
+table ManyUInt3x2 (fs_serializer)
+{
+    values: [uint3x2] (required);
+}
+
+table ManyUInt3x3 (fs_serializer)
+{
+    values: [uint3x3] (required);
+}
+
+table ManyUInt3x4 (fs_serializer)
+{
+    values: [uint3x4] (required);
+}
+
+table ManyUInt4x2 (fs_serializer)
+{
+    values: [uint4x2] (required);
+}
+
+table ManyUInt4x3 (fs_serializer)
+{
+    values: [uint4x3] (required);
+}
+
+table ManyUInt4x4 (fs_serializer)
+{
+    values: [uint4x4] (required);
+}
+
+table ManyBool2 (fs_serializer)
+{
+    values: [bool2] (required);
+}
+
+table ManyBool3 (fs_serializer)
+{
+    values: [bool3] (required);
+}
+
+table ManyBool4 (fs_serializer)
+{
+    values: [bool4] (required);
+}
+
+table ManyBool2x2 (fs_serializer)
+{
+    values: [bool2x2] (required);
+}
+
+table ManyBool2x3 (fs_serializer)
+{
+    values: [bool2x3] (required);
+}
+
+table ManyBool2x4 (fs_serializer)
+{
+    values: [bool2x4] (required);
+}
+
+table ManyBool3x2 (fs_serializer)
+{
+    values: [bool3x2] (required);
+}
+
+table ManyBool3x3 (fs_serializer)
+{
+    values: [bool3x3] (required);
+}
+
+table ManyBool3x4 (fs_serializer)
+{
+    values: [bool3x4] (required);
+}
+
+table ManyBool4x2 (fs_serializer)
+{
+    values: [bool4x2] (required);
+}
+
+table ManyBool4x3 (fs_serializer)
+{
+    values: [bool4x3] (required);
+}
+
+table ManyBool4x4 (fs_serializer)
+{
+    values: [bool4x4] (required);
+}
+
+table ManyDouble2 (fs_serializer)
+{
+    values: [double2] (required);
+}
+
+table ManyDouble3 (fs_serializer)
+{
+    values: [double3] (required);
+}
+
+table ManyDouble4 (fs_serializer)
+{
+    values: [double4] (required);
+}
+
+table ManyDouble2x2 (fs_serializer)
+{
+    values: [double2x2] (required);
+}
+
+table ManyDouble2x3 (fs_serializer)
+{
+    values: [double2x3] (required);
+}
+
+table ManyDouble2x4 (fs_serializer)
+{
+    values: [double2x4] (required);
+}
+
+table ManyDouble3x2 (fs_serializer)
+{
+    values: [double3x2] (required);
+}
+
+table ManyDouble3x3 (fs_serializer)
+{
+    values: [double3x3] (required);
+}
+
+table ManyDouble3x4 (fs_serializer)
+{
+    values: [double3x4] (required);
+}
+
+table ManyDouble4x2 (fs_serializer)
+{
+    values: [double4x2] (required);
+}
+
+table ManyDouble4x3 (fs_serializer)
+{
+    values: [double4x3] (required);
+}
+
+table ManyDouble4x4 (fs_serializer)
+{
+    values: [double4x4] (required);
+}

--- a/Unity.Mathematics.Serializable/Schemas/Unity.Mathematics.fbs
+++ b/Unity.Mathematics.Serializable/Schemas/Unity.Mathematics.fbs
@@ -1,0 +1,457 @@
+// Flatbuffer schema for generic math types (Linear Algebra)
+
+namespace Unity.Mathematics.Serializable;
+
+attribute "fs_valueStruct";
+attribute "fs_unsafeExternal";
+attribute "fs_nonVirtual";
+
+///-----------------------------------------------------------------------------
+/// float types
+
+/// 2D vector of floats
+struct float2(fs_valueStruct, native_inline, native_type: "float2", fs_unsafeExternal: "Unity.Mathematics.float2", fs_nonVirtual) {
+	x: float(native_default: "0");
+	y: float(native_default: "0");
+}
+
+/// 3D vector of floats
+struct float3(fs_valueStruct, native_inline, native_type: "float3", fs_unsafeExternal: "Unity.Mathematics.float3", fs_nonVirtual) {
+	x: float(native_default: "0");
+	y: float(native_default: "0");
+	z: float(native_default: "0");
+}
+
+/// 4D vector of floats (homogenous coordinates)
+struct float4(fs_valueStruct, native_inline, native_type: "float4", fs_unsafeExternal: "Unity.Mathematics.float4", fs_nonVirtual) {
+	x: float(native_default: "0");
+	y: float(native_default: "0");
+	z: float(native_default: "0");
+	w: float(native_default: "0");
+}
+
+/// 4D hypercomplex of floats
+struct quaternion(fs_valueStruct, native_inline, native_type: "quaternion", fs_unsafeExternal: "Unity.Mathematics.quaternion", fs_nonVirtual) {
+	x: float(native_default: "0");
+	y: float(native_default: "0");
+	z: float(native_default: "0");
+	w: float(native_default: "0");
+}
+
+/// 2x2 matrix of floats
+struct float2x2(fs_valueStruct, native_inline, native_type: "float2x2", fs_unsafeExternal: "Unity.Mathematics.float2x2", fs_nonVirtual) {
+	c0: float2(native_default: "{1,0}");
+	c1: float2(native_default: "{0,1}");
+}
+
+/// 2x3 matrix of floats
+struct float2x3(fs_valueStruct, native_inline, native_type: "float2x3", fs_unsafeExternal: "Unity.Mathematics.float2x3", fs_nonVirtual) {
+	c0: float2(native_default: "{1,0}");
+	c1: float2(native_default: "{0,1}");
+	c2: float2(native_default: "{0,0}");
+}
+
+/// 2x4 matrix of floats
+struct float2x4(fs_valueStruct, native_inline, native_type: "float2x4", fs_unsafeExternal: "Unity.Mathematics.float2x4", fs_nonVirtual) {
+	c0: float2(native_default: "{1,0}");
+	c1: float2(native_default: "{0,1}");
+	c2: float2(native_default: "{0,0}");
+	c3: float2(native_default: "{0,0}");
+}
+
+/// 3x2 matrix of floats
+struct float3x2(fs_valueStruct, native_inline, native_type: "float3x2", fs_unsafeExternal: "Unity.Mathematics.float3x2", fs_nonVirtual) {
+	c0: float3(native_default: "{1,0,0}");
+	c1: float3(native_default: "{0,1,0}");
+
+}
+
+/// 3x3 matrix of floats
+struct float3x3(fs_valueStruct, native_inline, native_type: "float3x3", fs_unsafeExternal: "Unity.Mathematics.float3x3", fs_nonVirtual) {
+	c0: float3(native_default: "{1,0,0}");
+	c1: float3(native_default: "{0,1,0}");
+	c2: float3(native_default: "{0,0,1}");
+}
+
+/// 3x4 matrix of floats
+struct float3x4(fs_valueStruct, native_inline, native_type: "float3x4", fs_unsafeExternal: "Unity.Mathematics.float3x4", fs_nonVirtual) {
+	c0: float3(native_default: "{1,0,0}");
+	c1: float3(native_default: "{0,1,0}");
+	c2: float3(native_default: "{0,0,1}");
+	c3: float3(native_default: "{0,0,0}");
+}
+
+/// 4x2 matrix of floats
+struct float4x2(fs_valueStruct, native_inline, native_type: "float4x2", fs_unsafeExternal: "Unity.Mathematics.float4x2", fs_nonVirtual) {
+	c0: float4(native_default: "{1,0,0,0}");
+	c1: float4(native_default: "{0,1,0,0}");
+}
+
+/// 4x3 matrix of floats
+struct float4x3(fs_valueStruct, native_inline, native_type: "float4x3", fs_unsafeExternal: "Unity.Mathematics.float4x3", fs_nonVirtual) {
+	c0: float4(native_default: "{1,0,0,0}");
+	c1: float4(native_default: "{0,1,0,0}");
+	c2: float4(native_default: "{0,0,1,0}");
+}
+
+/// 4x4 matrix of floats
+struct float4x4(fs_valueStruct, native_inline, native_type: "float4x4", fs_unsafeExternal: "Unity.Mathematics.float4x4", fs_nonVirtual) {
+	c0: float4(native_default: "{1,0,0,0}");
+	c1: float4(native_default: "{0,1,0,0}");
+	c2: float4(native_default: "{0,0,1,0}");
+	c3: float4(native_default: "{0,0,0,1}");
+}
+
+///-----------------------------------------------------------------------------
+///-----------------------------------------------------------------------------
+/// int types
+
+/// 2D vector of ints
+struct int2(fs_valueStruct, native_inline, native_type: "int2", fs_unsafeExternal: "Unity.Mathematics.int2", fs_nonVirtual) {
+	x: int(native_default: "0");
+	y: int(native_default: "0");
+}
+
+/// 3D vector of ints
+struct int3(fs_valueStruct, native_inline, native_type: "int3", fs_unsafeExternal: "Unity.Mathematics.int3", fs_nonVirtual) {
+	x: int(native_default: "0");
+	y: int(native_default: "0");
+	z: int(native_default: "0");
+}
+
+/// 4D vector of ints (homogenous coordinates)
+struct int4(fs_valueStruct, native_inline, native_type: "int4", fs_unsafeExternal: "Unity.Mathematics.int4", fs_nonVirtual) {
+	x: int(native_default: "0");
+	y: int(native_default: "0");
+	z: int(native_default: "0");
+	w: int(native_default: "0");
+}
+
+/// 2x2 matrix of ints
+struct int2x2(fs_valueStruct, native_inline, native_type: "int2x2", fs_unsafeExternal: "Unity.Mathematics.int2x2", fs_nonVirtual) {
+	c0: int2(native_default: "1,0");
+	c1: int2(native_default: "0,1");
+}
+
+/// 2x3 matrix of ints
+struct int2x3(fs_valueStruct, native_inline, native_type: "int2x3", fs_unsafeExternal: "Unity.Mathematics.int2x3", fs_nonVirtual) {
+	c0: int2(native_default: "1,0");
+	c1: int2(native_default: "0,1");
+	c2: int2(native_default: "0,0");
+}
+
+/// 2x4 matrix of ints
+struct int2x4(fs_valueStruct, native_inline, native_type: "int2x4", fs_unsafeExternal: "Unity.Mathematics.int2x4", fs_nonVirtual) {
+	c0: int2(native_default: "1,0");
+	c1: int2(native_default: "0,1");
+	c2: int2(native_default: "0,0");
+	c3: int2(native_default: "0,0");
+}
+
+/// 3x2 matrix of ints
+struct int3x2(fs_valueStruct, native_inline, native_type: "int3x2", fs_unsafeExternal: "Unity.Mathematics.int3x2", fs_nonVirtual) {
+	c0: int3(native_default: "1,0,0");
+	c1: int3(native_default: "0,1,0");
+}
+
+/// 3x3 matrix of ints
+struct int3x3(fs_valueStruct, native_inline, native_type: "int3x3", fs_unsafeExternal: "Unity.Mathematics.int3x3", fs_nonVirtual) {
+	c0: int3(native_default: "1,0,0");
+	c1: int3(native_default: "0,1,0");
+	c2: int3(native_default: "0,0,1");
+}
+
+/// 3x4 matrix of ints
+struct int3x4(fs_valueStruct, native_inline, native_type: "int3x4", fs_unsafeExternal: "Unity.Mathematics.int3x4", fs_nonVirtual) {
+	c0: int3(native_default: "1,0,0");
+	c1: int3(native_default: "0,1,0");
+	c2: int3(native_default: "0,0,1");
+	c3: int3(native_default: "0,0,0");
+}
+
+/// 4x2 matrix of ints
+struct int4x2(fs_valueStruct, native_inline, native_type: "int4x2", fs_unsafeExternal: "Unity.Mathematics.int4x2", fs_nonVirtual) {
+	c0: int4(native_default: "1,0,0,0");
+	c1: int4(native_default: "0,1,0,0");
+}
+
+/// 4x3 matrix of ints
+struct int4x3(fs_valueStruct, native_inline, native_type: "int4x3", fs_unsafeExternal: "Unity.Mathematics.int4x3", fs_nonVirtual) {
+	c0: int4(native_default: "1,0,0,0");
+	c1: int4(native_default: "0,1,0,0");
+	c2: int4(native_default: "0,0,1,0");
+}
+
+/// 4x4 matrix of ints
+struct int4x4(fs_valueStruct, native_inline, native_type: "int4x4", fs_unsafeExternal: "Unity.Mathematics.int4x4", fs_nonVirtual) {
+	c0: int4(native_default: "1,0,0,0");
+	c1: int4(native_default: "0,1,0,0");
+	c2: int4(native_default: "0,0,1,0");
+	c3: int4(native_default: "0,0,0,1");
+}
+
+///-----------------------------------------------------------------------------
+///-----------------------------------------------------------------------------
+/// uint types
+
+/// 2D vector of uints
+struct uint2(fs_valueStruct, native_inline, native_type: "uint2", fs_unsafeExternal: "Unity.Mathematics.uint2", fs_nonVirtual) {
+	x: uint(native_default: "0");
+	y: uint(native_default: "0");
+}
+
+/// 3D vector of uints
+struct uint3(fs_valueStruct, native_inline, native_type: "uint3", fs_unsafeExternal: "Unity.Mathematics.uint3", fs_nonVirtual) {
+	x: uint(native_default: "0");
+	y: uint(native_default: "0");
+	z: uint(native_default: "0");
+}
+
+/// 4D vector of uints (homogenous coordinates)
+struct uint4(fs_valueStruct, native_inline, native_type: "uint4", fs_unsafeExternal: "Unity.Mathematics.uint4", fs_nonVirtual) {
+	x: uint(native_default: "0");
+	y: uint(native_default: "0");
+	z: uint(native_default: "0");
+	w: uint(native_default: "0");
+}
+
+/// 2x2 matrix of uints
+struct uint2x2(fs_valueStruct, native_inline, native_type: "uint2x2", fs_unsafeExternal: "Unity.Mathematics.uint2x2", fs_nonVirtual) {
+	c0: uint2(native_default: "1,0");
+	c1: uint2(native_default: "0,1");
+}
+
+/// 2x3 matrix of uints
+struct uint2x3(fs_valueStruct, native_inline, native_type: "uint2x3", fs_unsafeExternal: "Unity.Mathematics.uint2x3", fs_nonVirtual) {
+	c0: uint2(native_default: "1,0");
+	c1: uint2(native_default: "0,1");
+	c2: uint2(native_default: "0,0");
+}
+
+/// 2x4 matrix of uints
+struct uint2x4(fs_valueStruct, native_inline, native_type: "uint2x4", fs_unsafeExternal: "Unity.Mathematics.uint2x4", fs_nonVirtual) {
+	c0: uint2(native_default: "1,0");
+	c1: uint2(native_default: "0,1");
+	c2: uint2(native_default: "0,0");
+	c3: uint2(native_default: "0,0");
+}
+
+/// 3x2 matrix of uints
+struct uint3x2(fs_valueStruct, native_inline, native_type: "uint3x2", fs_unsafeExternal: "Unity.Mathematics.uint3x2", fs_nonVirtual) {
+	c0: uint3(native_default: "1,0,0");
+	c1: uint3(native_default: "0,1,0");
+}
+
+/// 3x3 matrix of uints
+struct uint3x3(fs_valueStruct, native_inline, native_type: "uint3x3", fs_unsafeExternal: "Unity.Mathematics.uint3x3", fs_nonVirtual) {
+	c0: uint3(native_default: "1,0,0");
+	c1: uint3(native_default: "0,1,0");
+	c2: uint3(native_default: "0,0,1");
+}
+
+/// 3x4 matrix of uints
+struct uint3x4(fs_valueStruct, native_inline, native_type: "uint3x4", fs_unsafeExternal: "Unity.Mathematics.uint3x4", fs_nonVirtual) {
+	c0: uint3(native_default: "1,0,0");
+	c1: uint3(native_default: "0,1,0");
+	c2: uint3(native_default: "0,0,1");
+	c3: uint3(native_default: "0,0,0");
+}
+
+/// 4x2 matrix of uints
+struct uint4x2(fs_valueStruct, native_inline, native_type: "uint4x2", fs_unsafeExternal: "Unity.Mathematics.uint4x2", fs_nonVirtual) {
+	c0: uint4(native_default: "1,0,0,0");
+	c1: uint4(native_default: "0,1,0,0");
+}
+
+/// 4x3 matrix of uints
+struct uint4x3(fs_valueStruct, native_inline, native_type: "uint4x3", fs_unsafeExternal: "Unity.Mathematics.uint4x3", fs_nonVirtual) {
+	c0: uint4(native_default: "1,0,0,0");
+	c1: uint4(native_default: "0,1,0,0");
+	c2: uint4(native_default: "0,0,1,0");
+}
+
+/// 4x4 matrix of uints
+struct uint4x4(fs_valueStruct, native_inline, native_type: "uint4x4", fs_unsafeExternal: "Unity.Mathematics.uint4x4", fs_nonVirtual) {
+	c0: uint4(native_default: "1,0,0,0");
+	c1: uint4(native_default: "0,1,0,0");
+	c2: uint4(native_default: "0,0,1,0");
+	c3: uint4(native_default: "0,0,0,1");
+}
+
+///-----------------------------------------------------------------------------
+///-----------------------------------------------------------------------------
+/// boolean types
+
+/// 2D vector of bools
+struct bool2(fs_valueStruct, native_inline, native_type: "bool2", fs_unsafeExternal: "Unity.Mathematics.bool2", fs_nonVirtual) {
+	x: bool(native_default: "false");
+	y: bool(native_default: "false");
+}
+
+/// 3D vector of bools
+struct bool3(fs_valueStruct, native_inline, native_type: "bool3", fs_unsafeExternal: "Unity.Mathematics.bool3", fs_nonVirtual) {
+	x: bool(native_default: "false");
+	y: bool(native_default: "false");
+	z: bool(native_default: "false");
+}
+
+/// 4D vector of bools (homogenous coordinates)
+struct bool4(fs_valueStruct, native_inline, native_type: "bool4", fs_unsafeExternal: "Unity.Mathematics.bool4", fs_nonVirtual) {
+	x: bool(native_default: "false");
+	y: bool(native_default: "false");
+	z: bool(native_default: "false");
+	w: bool(native_default: "false");
+}
+
+/// 2x2 matrix of bools
+struct bool2x2(fs_valueStruct, native_inline, native_type: "bool2x2", fs_unsafeExternal: "Unity.Mathematics.bool2x2", fs_nonVirtual) {
+	c0: bool2(native_default: "true,false");
+	c1: bool2(native_default: "fale,true");
+}
+
+/// 2x3 matrix of bools
+struct bool2x3(fs_valueStruct, native_inline, native_type: "bool2x3", fs_unsafeExternal: "Unity.Mathematics.bool2x3", fs_nonVirtual) {
+	c0: bool2(native_default: "true,false");
+	c1: bool2(native_default: "fale,true");
+	c2: bool2(native_default: "fale,false");
+}
+
+/// 2x4 matrix of bools
+struct bool2x4(fs_valueStruct, native_inline, native_type: "bool2x4", fs_unsafeExternal: "Unity.Mathematics.bool2x4", fs_nonVirtual) {
+	c0: bool2(native_default: "true,false");
+	c1: bool2(native_default: "fale,true");
+	c2: bool2(native_default: "fale,false");
+	c3: bool2(native_default: "fale,false");
+}
+
+/// 3x2 matrix of bools
+struct bool3x2(fs_valueStruct, native_inline, native_type: "bool3x2", fs_unsafeExternal: "Unity.Mathematics.bool3x2", fs_nonVirtual) {
+	c0: bool3(native_default: "true,false,false");
+	c1: bool3(native_default: "fale,true,false");
+}
+
+/// 3x3 matrix of bools
+struct bool3x3(fs_valueStruct, native_inline, native_type: "bool3x3", fs_unsafeExternal: "Unity.Mathematics.bool3x3", fs_nonVirtual) {
+	c0: bool3(native_default: "true,false,false");
+	c1: bool3(native_default: "fale,true,false");
+	c2: bool3(native_default: "fale,false,true");
+}
+
+/// 3x4 matrix of bools
+struct bool3x4(fs_valueStruct, native_inline, native_type: "bool3x4", fs_unsafeExternal: "Unity.Mathematics.bool3x4", fs_nonVirtual) {
+	c0: bool3(native_default: "true,false,false");
+	c1: bool3(native_default: "fale,true,false");
+	c2: bool3(native_default: "fale,false,true");
+	c3: bool3(native_default: "fale,false,true");
+}
+
+/// 4x2 matrix of bools
+struct bool4x2(fs_valueStruct, native_inline, native_type: "bool4x2", fs_unsafeExternal: "Unity.Mathematics.bool4x2", fs_nonVirtual) {
+	c0: bool4(native_default: "true,false,false,false");
+	c1: bool4(native_default: "fale,true,false,false");
+}
+
+/// 4x3 matrix of bools
+struct bool4x3(fs_valueStruct, native_inline, native_type: "bool4x3", fs_unsafeExternal: "Unity.Mathematics.bool4x3", fs_nonVirtual) {
+	c0: bool4(native_default: "true,false,false,false");
+	c1: bool4(native_default: "fale,true,false,false");
+	c2: bool4(native_default: "fale,false,true,false");
+}
+
+/// 4x4 matrix of bools
+struct bool4x4(fs_valueStruct, native_inline, native_type: "bool4x4", fs_unsafeExternal: "Unity.Mathematics.bool4x4", fs_nonVirtual) {
+	c0: bool4(native_default: "true,false,false,false");
+	c1: bool4(native_default: "fale,true,false,false");
+	c2: bool4(native_default: "fale,false,true,false");
+	c3: bool4(native_default: "fale,false,false,true");
+}
+
+///-----------------------------------------------------------------------------
+///-----------------------------------------------------------------------------
+/// double types
+
+/// 2D vector of doubles
+struct double2(fs_valueStruct, native_inline, native_type: "double2", fs_unsafeExternal: "Unity.Mathematics.double2", fs_nonVirtual) {
+	x: double(native_default: "0");
+	y: double(native_default: "0");
+}
+
+/// 3D vector of doubles
+struct double3(fs_valueStruct, native_inline, native_type: "double3", fs_unsafeExternal: "Unity.Mathematics.double3", fs_nonVirtual) {
+	x: double(native_default: "0");
+	y: double(native_default: "0");
+	z: double(native_default: "0");
+}
+
+/// 4D vector of doubles (homogenous coordinates)
+struct double4(fs_valueStruct, native_inline, native_type: "double4", fs_unsafeExternal: "Unity.Mathematics.double4", fs_nonVirtual) {
+	x: double(native_default: "0");
+	y: double(native_default: "0");
+	z: double(native_default: "0");
+	w: double(native_default: "0");
+}
+
+/// 2x2 matrix of doubles
+struct double2x2(fs_valueStruct, native_inline, native_type: "double2x2", fs_unsafeExternal: "Unity.Mathematics.double2x2", fs_nonVirtual) {
+	c0: double2(native_default: "1,0");
+	c1: double2(native_default: "0,1");
+}
+
+/// 2x3 matrix of doubles
+struct double2x3(fs_valueStruct, native_inline, native_type: "double2x3", fs_unsafeExternal: "Unity.Mathematics.double2x3", fs_nonVirtual) {
+	c0: double2(native_default: "1,0");
+	c1: double2(native_default: "0,1");
+	c2: double2(native_default: "0,0");
+}
+
+/// 2x4 matrix of doubles
+struct double2x4(fs_valueStruct, native_inline, native_type: "double2x4", fs_unsafeExternal: "Unity.Mathematics.double2x4", fs_nonVirtual) {
+	c0: double2(native_default: "1,0");
+	c1: double2(native_default: "0,1");
+	c2: double2(native_default: "0,0");
+	c3: double2(native_default: "0,0");
+}
+
+/// 3x2 matrix of doubles
+struct double3x2(fs_valueStruct, native_inline, native_type: "double3x2", fs_unsafeExternal: "Unity.Mathematics.double3x2", fs_nonVirtual) {
+	c0: double3(native_default: "1,0,0");
+	c1: double3(native_default: "0,1,0");
+}
+
+/// 3x3 matrix of doubles
+struct double3x3(fs_valueStruct, native_inline, native_type: "double3x3", fs_unsafeExternal: "Unity.Mathematics.double3x3", fs_nonVirtual) {
+	c0: double3(native_default: "1,0,0");
+	c1: double3(native_default: "0,1,0");
+	c2: double3(native_default: "0,0,1");
+}
+
+/// 3x4 matrix of doubles
+struct double3x4(fs_valueStruct, native_inline, native_type: "double3x4", fs_unsafeExternal: "Unity.Mathematics.double3x4", fs_nonVirtual) {
+	c0: double3(native_default: "1,0,0");
+	c1: double3(native_default: "0,1,0");
+	c2: double3(native_default: "0,0,1");
+	c3: double3(native_default: "0,0,0");
+}
+
+/// 4x2 matrix of doubles
+struct double4x2(fs_valueStruct, native_inline, native_type: "double4x2", fs_unsafeExternal: "Unity.Mathematics.double4x2", fs_nonVirtual) {
+	c0: double4(native_default: "1,0,0,0");
+	c1: double4(native_default: "0,1,0,0");
+}
+
+/// 4x3 matrix of doubles
+struct double4x3(fs_valueStruct, native_inline, native_type: "double4x3", fs_unsafeExternal: "Unity.Mathematics.double4x3", fs_nonVirtual) {
+	c0: double4(native_default: "1,0,0,0");
+	c1: double4(native_default: "0,1,0,0");
+	c2: double4(native_default: "0,0,1,0");
+}
+
+/// 4x4 matrix of doubles
+struct double4x4(fs_valueStruct, native_inline, native_type: "double4x4", fs_unsafeExternal: "Unity.Mathematics.double4x4", fs_nonVirtual) {
+	c0: double4(native_default: "1,0,0,0");
+	c1: double4(native_default: "0,1,0,0");
+	c2: double4(native_default: "0,0,1,0");
+	c3: double4(native_default: "0,0,0,1");
+}
+
+///-----------------------------------------------------------------------------

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -7,4 +7,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Unity.Mathematics" Version="1.3.0-nuget.28" />
+  </ItemGroup>
+
 </Project>

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FlatSharp.Compiler" Version="7.2.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Unity.Mathematics" Version="1.3.0-nuget.28" />
   </ItemGroup>
 

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FlatSharpSchema Include="Schemas/Unity.Mathematics.fbs"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FlatSharp.Compiler" Version="7.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <FlatSharpSchema Include="Schemas/Unity.Mathematics.fbs"/>
+    <FlatSharpSchema Include="Schemas/Unity.Mathematics.Tables.fbs"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -7,6 +7,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <FlatSharpNameNormalization>false</FlatSharpNameNormalization>
+    <FlatSharpNullable>true</FlatSharpNullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="FlatSharp.Compiler" Version="7.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
+++ b/Unity.Mathematics.Serializable/Unity.Mathematics.Serializable.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FlatSharp.Runtime" Version="7.2.1" />
     <PackageReference Include="Unity.Mathematics" Version="1.3.0-nuget.28" />
   </ItemGroup>
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "Unity.Mathematics.Serializable/bin/Release/netstandard2.1/*.meta"
     ],
     "dependencies": {
-        "com.unity.mathematics": "1.3.0"
+        "com.unity.mathematics": "1.3.0",
+        "com.github.jamescourtney.flatsharp.runtime": "7.2.1"
     },
     "keywords": [
         "csharp",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
         "Unity.Mathematics.Serializable/bin/Release/netstandard2.1/*.pdb",
         "Unity.Mathematics.Serializable/bin/Release/netstandard2.1/*.meta"
     ],
-    "dependencies": {},
+    "dependencies": {
+        "com.unity.mathematics": "1.3.0"
+    },
     "keywords": [
         "csharp",
         "mathematics",


### PR DESCRIPTION
- build: add dependency on 'Unity.Mathematics', v1.3.0-nuget.28
- build: add dependency on 'FlatSharp.Compiler', v7.2.1
- build: add dependency on 'FlatSharp.Runtime', v7.2.1
- build: add PropertyGroup for FlatSharp.Compiler settings
- feature: implement FlatBuffer schema for 'Unity.Mathematics' types
- feature: implement FlatBuffer schema for 'Unity.Mathematics' types wrapped into FlatBuffer tables
- build: change package name
