### PR TITLE
refactor ('build' job): call 'nuget-add-registry' action before 'build' action

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -15,6 +15,10 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -14,6 +14,10 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,6 +16,10 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,10 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+    - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}


### PR DESCRIPTION
- refactor ('build-pr/build' job): call 'nuget-add-registry' before 'build'
- refactor ('build-ci/build' job): call 'nuget-add-registry' before 'build'
- refactor ('build-cron/build' job): call 'nuget-add-registry' before 'build'
- refactor ('publish/build' job): call 'nuget-add-registry' before 'build'
